### PR TITLE
Fixed close

### DIFF
--- a/src/Network/Multicast.hsc
+++ b/src/Network/Multicast.hsc
@@ -73,7 +73,7 @@ multicastSender host port = do
 -- >         print (msg, addr) in loop
 --
 multicastReceiver :: HostName -> PortNumber -> IO Socket
-multicastReceiver host port = bracketOnError get close setup
+multicastReceiver host port = bracketOnError get sClose setup
   where
     get :: IO Socket
     get = do


### PR DESCRIPTION
The Network.Socket binding uses the name sClose, not close.
