### PR TITLE
Fix WSAEADDRNOTAVAIL error on Windows platform

### DIFF
--- a/src/Network/Multicast.hsc
+++ b/src/Network/Multicast.hsc
@@ -88,9 +88,8 @@ multicastReceiver host port = bracketOnError get sClose setup
 #endif
     setup :: Socket -> IO Socket
     setup sock = do
-      (addrInfo:_) <- getAddrInfo Nothing (Just host) (Just $ show port)
+      bindSocket sock $ SockAddrInet port iNADDR_ANY
       addMembership sock host Nothing
-      bindSocket sock $ addrAddress addrInfo
       return sock
 
 doSetSocketOption :: Storable a => CInt -> Socket -> a -> IO CInt


### PR DESCRIPTION
Hi, 

The PR fixes #12 and haskell-distributed/distributed-process-simplelocalnet#18 .

On Windows platform one should bind multicast socket to `INADDR_ANY` or particular network interface address. An attempt to use multicast host as socket address raises `WSAEADDRNOTAVAIL` error.

The PR uses the `INADDR_ANY` approach as good enough. Binding to network interface requires additional dependencies on, for instance, `network-info` package, but behaves identically as proposed fix.

Tested on: Windows 7 x86_64 and Fedora 23 x86_64. 