### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/network-multicast.cabal
+++ b/network-multicast.cabal
@@ -11,7 +11,7 @@ description:        The "Network.Multicast" module is for sending
 stability:          experimental
 build-type:         Simple
 category:           Network
-cabal-version:      >= 1.6
+cabal-version:      >= 1.8
 extra-source-files: examples/sender.hs examples/receiver.hs ChangeLog
 
 library


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: network-multicast.cabal:20:37: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.          
```